### PR TITLE
feat(mongo): add SpanNameResolver for customizable span naming

### DIFF
--- a/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/config.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/config.go
@@ -18,6 +18,8 @@ type config struct {
 	Tracer trace.Tracer
 
 	CommandAttributeDisabled bool
+
+	SpanNameResolver SpanNameResolverFunc
 }
 
 // newConfig returns a config with all Options set.
@@ -26,6 +28,15 @@ func newConfig(opts ...Option) config {
 		TracerProvider:           otel.GetTracerProvider(),
 		CommandAttributeDisabled: true,
 	}
+
+	cfg.SpanNameResolver = func(collection string, command string) string {
+		if collection != "" {
+			return collection + "." + command
+		}
+
+		return command
+	}
+
 	for _, opt := range opts {
 		opt.apply(&cfg)
 	}
@@ -46,6 +57,20 @@ type optionFunc func(*config)
 
 func (o optionFunc) apply(c *config) {
 	o(c)
+}
+
+type SpanNameResolverFunc func(collection string, command string) string
+
+// WithSpanNameResolver specifies a function that resolves the span name given the
+// collection and command name. If none is specified, the default resolver is used,
+// which returns "<collection>.<command>" if the collection is non-empty, and just
+// "<command>" otherwise.
+func WithSpanNameResolver(resolver SpanNameResolverFunc) Option {
+	return optionFunc(func(cfg *config) {
+		if resolver != nil {
+			cfg.SpanNameResolver = resolver
+		}
+	})
 }
 
 // WithTracerProvider specifies a tracer provider to use for creating a tracer.

--- a/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/mongo.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/mongo.go
@@ -30,8 +30,6 @@ type monitor struct {
 }
 
 func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
-	var spanName string
-
 	hostname, port := peerInfo(evt)
 
 	attrs := []attribute.KeyValue{
@@ -45,11 +43,14 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 	if !m.cfg.CommandAttributeDisabled {
 		attrs = append(attrs, semconv.DBQueryText(sanitizeCommand(evt.Command)))
 	}
-	if collection, err := extractCollection(evt); err == nil && collection != "" {
-		spanName = collection + "."
+
+	collection, err := extractCollection(evt)
+	if err == nil && collection != "" {
 		attrs = append(attrs, semconv.DBCollectionName(collection))
 	}
-	spanName += evt.CommandName
+
+	spanName := m.cfg.SpanNameResolver(collection, evt.CommandName)
+
 	opts := []trace.SpanStartOption{
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(attrs...),

--- a/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/mongo_test.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/v2/mongo/otelmongo/mongo_test.go
@@ -24,6 +24,75 @@ import (
 
 type validator func(sdktrace.ReadOnlySpan) bool
 
+func TestWithSpanNameResolver(t *testing.T) {
+	tt := []struct {
+		title            string
+		operation        func(context.Context, *mongo.Database) (any, error)
+		expectedSpanName string
+		mockResponses    []bson.D
+		spanNameResolver SpanNameResolverFunc
+	}{
+		{
+			title: "insert",
+			operation: func(ctx context.Context, db *mongo.Database) (any, error) {
+				return db.Collection("test-collection").InsertOne(ctx, bson.D{{Key: "test-item", Value: "test-value"}})
+			},
+			expectedSpanName: "test-collection.insert",
+			spanNameResolver: nil,
+			mockResponses:    []bson.D{{{Key: "ok", Value: 1}}},
+		},
+		{
+			title: "delete",
+			operation: func(ctx context.Context, db *mongo.Database) (any, error) {
+				return db.Collection("test-collection").DeleteOne(ctx, bson.D{{Key: "test-item", Value: "test-value"}})
+			},
+			spanNameResolver: func(collection string, command string) string {
+				return "my-" + command + "-span"
+			},
+			expectedSpanName: "my-delete-span",
+			mockResponses:    []bson.D{{{Key: "ok", Value: 1}}},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.title, func(t *testing.T) {
+			md := drivertest.NewMockDeployment()
+
+			sr := tracetest.NewSpanRecorder()
+			provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second*3)
+			defer cancel()
+
+			ctx, span := provider.Tracer("test").Start(ctx, "mongodb-test")
+			addr := "mongodb://localhost:27017/?connect=direct"
+			opts := options.Client()
+			opts.Deployment = md //nolint:staticcheck // This method is the current documented way to set the mongodb mock. See https://github.com/mongodb/mongo-go-driver/blob/v2.0.0/x/mongo/driver/drivertest/opmsg_deployment_test.go#L24
+			opts.Monitor = NewMonitor(
+				WithTracerProvider(provider),
+				WithSpanNameResolver(tc.spanNameResolver),
+			)
+			opts.ApplyURI(addr)
+
+			md.AddResponses(tc.mockResponses...)
+			client, err := mongo.Connect(opts)
+			defer func() {
+				e := client.Disconnect(t.Context())
+				require.NoError(t, e)
+			}()
+			require.NoError(t, err)
+
+			_, err = tc.operation(ctx, client.Database("test-database"))
+			require.NoError(t, err)
+
+			span.End()
+			spans := sr.Ended()
+
+			s := spans[0]
+			assert.Equal(t, tc.expectedSpanName, s.Name())
+		})
+	}
+}
+
 func TestDBCrudOperation(t *testing.T) {
 	commonValidators := []validator{
 		func(s sdktrace.ReadOnlySpan) bool {


### PR DESCRIPTION
This PR adds a SpanNameResolver function to the monitor options in order to customize the span name to the users needs. This is especially relevant when dealing with multiple database instances, having to prefix spans, or generally needing to customize the span name. 